### PR TITLE
Add OS class

### DIFF
--- a/src/OS/OS.php
+++ b/src/OS/OS.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DexproSolutionsGmbh\PhpCommons\OS;
+
+/**
+ * OS is possibly the simplest helper class you can imagine: It helps you in
+ * checking if your operating system is linux, windows or something unknown.
+ */
+class OS
+{
+    public const LINUX = 'linux';
+
+    public const WINDOWS = 'windows';
+
+    public const UNKNOWN = 'unknown';
+
+    public static function getOperatingSystem(): string
+    {
+        switch (PHP_OS) {
+            case 'WIN32':
+            case 'WINNT':
+            case 'Windows':
+                $system = self::WINDOWS;
+                break;
+            case 'Linux':
+                $system = self::LINUX;
+                break;
+            default:
+                $system = self::UNKNOWN;
+                break;
+        }
+
+        return $system;
+    }
+
+    public function isWindows(): bool
+    {
+        return self::getOperatingSystem() === self::WINDOWS;
+    }
+
+    public function isLinux(): bool
+    {
+        return self::getOperatingSystem() === self::LINUX;
+    }
+}


### PR DESCRIPTION
The added code has often been used to check for the host's operating system. Yes, this can be done simpler (use `OS_UNIX`) but the purpose of this addition is to move this code into the commons library.

More interesting helpers will follow 😉 